### PR TITLE
log full address with port to console

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -7,5 +7,5 @@ database.connect(process.env.MONGO_URI);
 const PORT = process.env.PORT || 8000;
 
 app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
+  console.log(`Server running on port ${PORT} : http://localhost:${PORT}`);
 });


### PR DESCRIPTION
In VSCode IDE some ports don't automatically get forwarded when running an application from the terminal. 

Why is this? 

VSCode will look into proc file system over some OS for ports to auto forward, but not on mac/windows. Instead they parse terminal output for `http://localhost:{PORT}`. 